### PR TITLE
There is a problem that the title element of the top page includes the description of the site. | Flag for console of category page is not set.

### DIFF
--- a/layout/includes/layout.pug
+++ b/layout/includes/layout.pug
@@ -1,5 +1,8 @@
-- var pageTitle = page.title || config.description || config.title || config.subtitle || ''
-- pageTitle += ' | ' + config.title
+- var pageTitle = page.title || ''
+if pageTitle != ''
+    - pageTitle += ' | ' + config.title
+else
+    - pageTitle = config.title
 
 doctype html
 html(lang=config.language)

--- a/layout/includes/terminal.pug
+++ b/layout/includes/terminal.pug
@@ -7,8 +7,10 @@ if page.title === 'about'
   - flag = 1
 else if page.title === 'tags'
   - flag = 2
-else if is_post()
+else if page.title === 'categories'
   - flag = 3
+else if is_post()
+  - flag = 4
 - var objName = objNames[flag]
 #terminal-pl
   #top-bar
@@ -40,6 +42,8 @@ else if is_post()
     if flag === 2
       include ./terminal/terminal-tags.pug
     else if flag === 3
+      include ./terminal/terminal-categories.pug
+    else if flag === 4
       include ./terminal/terminal-post.pug
       
       


### PR DESCRIPTION
I think that it is good to display only the site title in the title element of the top page. 90deb38
## On the top page:
`Site description | Site Title` => `Site Title`
## On the other page:
`Page Title | Site Title`