### PR TITLE
There is a problem that the previous post and the next post are displayed in reverse on the post page. | Tag links do not work properly on the post page.

### DIFF
--- a/layout/includes/terminal/terminal-post.pug
+++ b/layout/includes/terminal/terminal-post.pug
@@ -9,22 +9,22 @@ if page.categories
   br
   br
 if page.tags.data
-  | > #{objName}.tags 
+  | > #{objName}.tags
   br
   each val in page.tags.data
-    a(href='#'+val.name class="tag")
+    a(href='/tags/#'+val.name class="tag")
       span= val.name
   br
   br
-if page.prev
-  | > #{objName}.prev 
-  br
-  a(href=url_for(page.prev.path))
-    span.answer= page.prev.title
-  br
-  br
 if page.next
-  | > #{objName}.next 
+  | > #{objName}.prev
   br
   a(href=url_for(page.next.path))
     span.answer= page.next.title
+  br
+  br
+if page.prev
+  | > #{objName}.next
+  br
+  a(href=url_for(page.prev.path))
+    span.answer= page.prev.title


### PR DESCRIPTION
- Fixed an issue where the previous post and the next post are displayed in reverse on the post page.
(However, the variable name of what is working remains opposite)
- Fixed an issue where tag links did not work properly on post page.